### PR TITLE
added A-4E-C and UH-60L

### DIFF
--- a/extract_module_main.lua
+++ b/extract_module_main.lua
@@ -4,11 +4,11 @@ dcs_install_path = [[C:\Program Files\Eagle Dynamics\DCS World OpenBeta]]
 module_name = "A-10C"
 
 -- Modules:
--- A-10C, AJS37, AV8BNA, Bf-109K-4, C-101CC, C-101EB, Christen Eagle II,
+-- A-10C, A-4E-C, AJS37, AV8BNA, Bf-109K-4, C-101CC, C-101EB, Christen Eagle II,
 -- F-16C, F-5E, F-86, F14, FA-18C, FW-190A8, FW-190D9, I-16, JF-17, Ka-50,
 -- L-39C, L-39ZA, M-2000C, MIG-21bis, Mi-8MTV2, MiG-15bis, MiG-19P, Mi-24P, 
 -- MosquitoFBMkVI, P-47D-30, P-51D, SA342, SpitfireLFMkIX, Su-25T, Su-33, 
--- TF-51D, Uh-1H, Yak-52
+-- TF-51D, Uh-1H, UH-60L, Yak-52
 
 -- End of user configurable data
 


### PR DESCRIPTION
Had to have the mods within the DCS main install path for aircraft to work correctly. Remember to remove the mods before starting DCS.